### PR TITLE
added install script for pi

### DIFF
--- a/install/installRPi.sh
+++ b/install/installRPi.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# installRPi.sh: install centinel on Raspbian
+
+sudo apt-get install python-pip python-m2crypto
+sudo pip install --upgrade centinel-dev
+
+# write out a centinel test script to cron.hourly
+sudo echo "#!/bin/bash" > /etc/cron.hourly/centinel
+sudo echo "# cron job for centinel" >> /etc/cron.hourly/centinel
+sudo echo "/usr/local/bin/centinel-dev" >> /etc/cron.hourly/centinel
+sudo echo "/usr/local/bin/centinel-dev --sync" >> /etc/cron.hourly/centinel
+sudo chmod +x /etc/cron.hourly/centinel

--- a/install/installRPi.sh
+++ b/install/installRPi.sh
@@ -3,14 +3,18 @@
 # installRPi.sh: install centinel on Raspbian
 
 sudo apt-get install python-pip python-m2crypto
+sudo pip uninstall centinel
 sudo pip install --upgrade centinel-dev
 
 # write out a centinel test script to cron.hourly
 sudo rm -f /etc/cron.hourly/centinel
-echo "#!/bin/bash"                         > centinel-hourly-run
-echo "# cron job for centinel"            >> centinel-hourly-run
-echo "/usr/local/bin/centinel-dev"        >> centinel-hourly-run
-echo "/usr/local/bin/centinel-dev --sync" >> centinel-hourly-run
+echo "#!/bin/bash"                                > centinel-hourly-run
+echo "# cron job for centinel"                   >> centinel-hourly-run
+echo 'sleepTime=$(($RANDOM % $(expr 60 \* 15)))' >> centinel-hourly-run
+echo 'sleep $sleepTime'                          >> centinel-hourly-run
+echo "/usr/local/bin/centinel-dev --sync"        >> centinel-hourly-run
+echo "/usr/local/bin/centinel-dev"               >> centinel-hourly-run
+echo "/usr/local/bin/centinel-dev --sync"        >> centinel-hourly-run
 sudo mv centinel-hourly-run /etc/cron.hourly/centinel
 sudo chmod +x /etc/cron.hourly/centinel
 

--- a/install/installRPi.sh
+++ b/install/installRPi.sh
@@ -11,3 +11,9 @@ sudo echo "# cron job for centinel" >> /etc/cron.hourly/centinel
 sudo echo "/usr/local/bin/centinel-dev" >> /etc/cron.hourly/centinel
 sudo echo "/usr/local/bin/centinel-dev --sync" >> /etc/cron.hourly/centinel
 sudo chmod +x /etc/cron.hourly/centinel
+
+# write out a centinel autoupdate script
+sudo echo "#!/bin/bash" > /etc/cron.daily/centinel
+sudo echo "# cron job for centinel autoupdate" >> /etc/cron.daily/centinel-autoupdate
+sudo echo "sudo pip install --upgrade centinel-dev" >> /etc/cron.daily/centinel-autoupdate
+sudo chmod +x /etc/cron.daily/centinel-autoupdate

--- a/install/installRPi.sh
+++ b/install/installRPi.sh
@@ -6,14 +6,18 @@ sudo apt-get install python-pip python-m2crypto
 sudo pip install --upgrade centinel-dev
 
 # write out a centinel test script to cron.hourly
-sudo echo "#!/bin/bash" > /etc/cron.hourly/centinel
-sudo echo "# cron job for centinel" >> /etc/cron.hourly/centinel
-sudo echo "/usr/local/bin/centinel-dev" >> /etc/cron.hourly/centinel
-sudo echo "/usr/local/bin/centinel-dev --sync" >> /etc/cron.hourly/centinel
+sudo rm -f /etc/cron.hourly/centinel
+echo "#!/bin/bash"                         > centinel-hourly-run
+echo "# cron job for centinel"            >> centinel-hourly-run
+echo "/usr/local/bin/centinel-dev"        >> centinel-hourly-run
+echo "/usr/local/bin/centinel-dev --sync" >> centinel-hourly-run
+sudo mv centinel-hourly-run /etc/cron.hourly/centinel
 sudo chmod +x /etc/cron.hourly/centinel
 
 # write out a centinel autoupdate script
-sudo echo "#!/bin/bash" > /etc/cron.daily/centinel
-sudo echo "# cron job for centinel autoupdate" >> /etc/cron.daily/centinel-autoupdate
-sudo echo "sudo pip install --upgrade centinel-dev" >> /etc/cron.daily/centinel-autoupdate
+sudo rm -f /etc/cron.daily/centinel-autoupdate
+echo "#!/bin/bash"                              > centinel-autoupdate-script
+echo "# cron job for centinel autoupdate"      >> centinel-autoupdate-script
+echo "sudo pip install --upgrade centinel-dev" >> centinel-autoupdate-script
+sudo mv centinel-autoupdate-script /etc/cron.daily/centinel-autoupdate
 sudo chmod +x /etc/cron.daily/centinel-autoupdate


### PR DESCRIPTION
I added an install script for RPi/ Raspbian. I am doing this as opposed to doing everything in pip because
a) the pip package for one our our dependencies, m2crypto, appears to be broken/ have unresolved dependenceis
b) I don't want to take the time to package cron.hourly files

@gsathya, would you please review this?