### PR TITLE
updated bundle location independent of cur dir

### DIFF
--- a/centinel/backend.py
+++ b/centinel/backend.py
@@ -2,13 +2,9 @@ import glob
 import json
 import logging
 import os
-import os.path
 import requests
 import time
 import uuid
-
-CERT_BUNDLE = os.path.join(os.path.dirname(__file__),
-                           "data/gd_bundle-g2-g1.crt")
 
 
 class User:
@@ -28,7 +24,7 @@ class User:
         url = "%s/%s" % (self.config['server']['server_url'], slug)
         req = requests.get(url, auth=self.auth,
                            proxies=self.config['proxy']['proxy'],
-                           verify=CERT_BUNDLE)
+                           verify=self.config['server']['cert_bundle'])
         req.raise_for_status()
 
         return req.json()
@@ -58,7 +54,7 @@ class User:
             req   = requests.post(url, proxies=self.config['proxy']['proxy'],
                                   files=files, auth=self.auth,
                                   timeout=self.config['server']['req_timeout'],
-                                  verify=CERT_BUNDLE)
+                                  verify=self.config['server']['cert_bundle'])
 
         req.raise_for_status()
         os.remove(file_name)
@@ -69,7 +65,7 @@ class User:
         url = "%s/%s/%s" % (self.config['server']['server_url'],
                             "experiments", name)
         req = requests.get(url, proxies=self.config['proxy']['proxy'],
-                           verify=CERT_BUNDLE,
+                           verify=self.config['server']['cert_bundle'],
                            auth=self.auth)
         req.raise_for_status()
 
@@ -88,7 +84,7 @@ class User:
         req     = requests.post(url, data=json.dumps(payload),
                                 proxies=self.config['proxy']['proxy'],
                                 headers=headers,
-                                verify=CERT_BUNDLE)
+                                verify=self.config['server']['cert_bundle'])
 
         req.raise_for_status()
 

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -46,6 +46,8 @@ class Configuration():
         # set a socket timeout of 15 seconds (no way to do per request
         # platform independently)
         servers['req_timeout'] = 15
+        servers['cert_bundle'] = os.path.join(os.path.dirname(__file__),
+                                              "data/gd_bundle-g2-g1.crt")
         self.params['server'] = servers
 
         # proxy


### PR DESCRIPTION
This makes our reference to the cert bundle location independent.

@gsathya, Please review this as soon as you can.

Also, I added an import of os.path in addition to os to show that we have a dependency on os.path, not just os. Since the only reason os.path gets imported is because os lists it in its **init**.py, I want to make the additional dependency clear.
