### PR TITLE
Results archiving

### DIFF
--- a/centinel/backend.py
+++ b/centinel/backend.py
@@ -113,7 +113,7 @@ def sync(config):
     # send all results
     # XXX: delete all files after sync?
     for path in glob.glob(os.path.join(config['dirs']['results_dir'],
-        '[!_]*.tar.%s' % config['results']['archive_encoding'])):
+        '[!_]*.tar.bz2')):
         try:
             user.submit_result(path)
             os.remove(path)

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -92,29 +92,28 @@ class Client():
         if len(result_files) >= self.config['results']['files_per_archive']:
             logging.info("Compressing and archiving results.")
 
-            encoding = self.config['results']['archive_encoding']
             files_archived = 0
             archive_count = 0
-            tar = ""
+            tar_file = None
 
             for path in result_files:
                 if files_archived % self.config['results']['files_per_archive'] == 0:
                     archive_count += 1
-                    archive_filename = "results-%s_%d.tar.%s" % (
-                        datetime.now().isoformat(), archive_count, encoding)
+                    archive_filename = "results-%s_%d.tar.bz2" % (
+                        datetime.now().isoformat(), archive_count)
                     archive_file_path = os.path.join(self.config['dirs']['results_dir'],
                         archive_filename)
                     logging.info("Creating new archive (%s)." % archive_file_path)
-                    if tar:
-                        tar.close()
-                    tar = tarfile.open(archive_file_path, "w:%s" % encoding)
+                    if tar_file:
+                        tar_file.close()
+                    tar_file = tarfile.open(archive_file_path, "w:bz2")
 
-                tar.add(path,
-                        arcname = os.path.basename(path))
+                tar_file.add(path,
+                             arcname = os.path.basename(path))
                 os.remove(path)
                 files_archived += 1
 
-            if tar:
-                tar.close()
+            if tar_file:
+                tar_file.close()
 
         logging.info("All experiments over. Check results.")

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -30,8 +30,6 @@ class Configuration():
 
         # results
         results = {}
-        # archive encoding can be either "bz2" or "gz"
-        results['archive_encoding'] = "bz2"
         results['files_per_archive'] = 10
         self.params['results'] = results
 


### PR DESCRIPTION
Added results archiving.
Result files are archived if the number of .json files exceeds n (specified in config). For each n files, a new archive is created (encoding specified in config).
Archive files are deleted after being sent to the server.
This should address issue #55.
