### PR TITLE
Random test subset

### DIFF
--- a/centinel/client.py
+++ b/centinel/client.py
@@ -63,12 +63,12 @@ class Client():
         experiments = self.load_experiments()
         experiments_subset = experiments.items()
 
-        if self.config['experiments']['random_subset']:
+        if self.config['experiments']['random_subsetting']:
             experiments_subset = [
                 experiments.items()[i] for i in sorted(
                     random.sample(xrange(len(experiments.items())),
                                   self.config['experiments']
-                                             ['subset_size']))
+                                             ['random_subset_size']))
             ]
 
         for name, Exp in experiments_subset:

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -43,8 +43,8 @@ class Configuration():
 
         # experiments
         experiments = {}
-        experiments['random_subset'] = True
-        experiments['subset_size'] = 2
+        experiments['random_subsetting'] = True
+        experiments['random_subset_size'] = 2
         self.params['experiments'] = experiments
 
         # server


### PR DESCRIPTION
If enabled by config, only run a random subset of the experiments. Subset size is also sepcified in config.
This addresses issue #57.
