### PR TITLE
bug fix for random subsetting and scheduler, fixes #104 and #103

### DIFF
--- a/centinel/client.py
+++ b/centinel/client.py
@@ -46,6 +46,7 @@ class Client():
 
         sched_filename = os.path.join(self.config['dirs']['experiments_dir'],
                                       'scheduler.info')
+        sched_info = {}
         if os.path.exists(sched_filename):
             with open(sched_filename, 'r') as file_p:
                 sched_info = json.load(file_p)
@@ -99,7 +100,9 @@ class Client():
         experiments = self.load_experiments()
         experiments_subset = experiments.items()
 
-        if self.config['experiments']['random_subsetting']:
+        if self.config['experiments']['random_subsetting'] and \
+               self.config['experiments']['random_subset_size'] < \
+                   len(experiments.items()):
             experiments_subset = [
                 experiments.items()[i] for i in sorted(
                     random.sample(xrange(len(experiments.items())),


### PR DESCRIPTION
This will fix a bug where centinel crashes in the absence of a scheduler.info or when there are fewer experiments present than the size of the random subset specified by the configuration file.
@ben-jones, can you review this please? I need this in order to update the pip package.
