### PR TITLE
Add encoding info to the generated results json

### DIFF
--- a/centinel/client.py
+++ b/centinel/client.py
@@ -132,7 +132,7 @@ class Client():
 
             results[name] = exp.results
 
-        json.dump(results, result_file)
+        json.dump(results, result_file, encoding="ISO-8859-1")
         result_file.close()
 
         result_files = [path for path in glob.glob(


### PR DESCRIPTION
Added encoding ISO-8859-1 to the generated json to avoid encoding errors decoding certain information with special characters (example certain websites bodies stored in the http-request experiment)
