### PR TITLE
added optional delete for results files, closes #115

### DIFF
--- a/centinel/backend.py
+++ b/centinel/backend.py
@@ -97,7 +97,8 @@ class User:
                                     proxies=self.config['proxy']['proxy'],
                                     timeout=timeout, verify=cert_bundle)
                 req.raise_for_status()
-                os.remove(file_name)
+                if config['results']['delete_after_sync']:
+                    os.remove(file_name)
             except Exception as exp:
                 logging.error("Error trying to submit result: %s" % exp)
                 raise exp

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -45,6 +45,7 @@ class Configuration():
 
         # results
         results = {}
+        results['delete_after_sync'] = True
         results['files_per_archive'] = 10
         self.params['results'] = results
 


### PR DESCRIPTION
This will make it optional to delete results after sync via config file (delete by default).
Note that disabling this will cause the client to send all of the results files everytime it syncs, but this is unlikely to happen often.
@ben-jones, can you please review?