### PR TITLE
Tcpdump

### DIFF
--- a/centinel/backend.py
+++ b/centinel/backend.py
@@ -260,11 +260,15 @@ def sync(config):
 
     # send all results (.tar.bz2 + .json + .pcap.bz2)
     result_files = (glob.glob(os.path.join(config['dirs']['results_dir'],
-                                                 '[!_]*.tar.bz2')) +
+                                           '[!_]*.tar.bz2')) +
                     glob.glob(os.path.join(config['dirs']['results_dir'],
-                                                      '[!_]*.json')) +
-                    glob.glob(os.path.join(config['dirs']['results_dir'],
-                                                      '[!_]*.pcap.bz2')))
+                                           '[!_]*.json')))
+
+    # only upload pcaps if it is allowed
+    if config['results']['upload_pcaps']:
+        result_files = (result_files +
+                        glob.glob(os.path.join(config['dirs']['results_dir'],
+                                               '[!_]*.pcap.bz2')))
 
     for path in result_files:
         try:

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -135,7 +135,7 @@ class Client():
                 td = Tcpdump()
                 tcpdump_started = False
                 try:
-                    if root:
+                    if root and self.config['results']['record_pcaps']:
                         td.start()
                         tcpdump_started = True
                         logging.info("tcpdump started...")
@@ -144,6 +144,7 @@ class Client():
                 except Exception as e:
                     logging.warning("Failed to run tcpdump: %s" %(e))
 
+                # run the experiment
                 exp = Exp(input_file)
                 exp.run()
 

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -134,6 +134,7 @@ class Client():
 
                 td = Tcpdump()
                 tcpdump_started = False
+
                 try:
                     if root and self.config['results']['record_pcaps']:
                         td.start()
@@ -155,18 +156,20 @@ class Client():
                     time.sleep(5)
                     td.stop()
                     logging.info("tcpdump stopped.")
+                    try:
+                        pcap_file_name = "pcap_%s-%s.pcap.bz2" % (name, 
+                            datetime.now().isoformat())
 
-                    pcap_file_name = "pcap_%s-%s.pcap.bz2" % (name, 
-                        datetime.now().isoformat())
+                        pcap_file_path = os.path.join(
+                            self.config['dirs']['results_dir'], pcap_file_name)
 
-                    pcap_file_path = os.path.join(
-                        self.config['dirs']['results_dir'], pcap_file_name)
-
-                    with open(pcap_file_path, 'w:bz2') as file_p:
-                        data = bz2.compress(td.pcap())
-                        file_p.write(data)
-                        logging.info("Saved pcap to %s."
-                                     % (pcap_file_path))
+                        with open(pcap_file_path, 'w:bz2') as file_p:
+                            data = bz2.compress(td.pcap())
+                            file_p.write(data)
+                            logging.info("Saved pcap to %s."
+                                         % (pcap_file_path))
+                    except Exception as e:
+                        logging.warning("Failed to write pcap file: %s" %(e))
 
             except Exception, e:
                 logging.error("Error in %s: %s" % (name, str(e)))

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -139,6 +139,8 @@ class Client():
                         td.start()
                         tcpdump_started = True
                         logging.info("tcpdump started...")
+                        # wait for tcpdump to initialize
+                        time.sleep(2)
                 except Exception as e:
                     logging.warning("Failed to run tcpdump: %s" %(e))
 

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -1,3 +1,4 @@
+import bz2
 import glob
 import imp
 import json
@@ -12,6 +13,7 @@ from datetime import datetime
 
 from experiment import Experiment, ExperimentList
 
+from centinel.primitives.tcpdump import Tcpdump
 
 class Client():
 
@@ -123,8 +125,46 @@ class Client():
 
             try:
                 logging.info("Running %s test." % (name))
+
+                root = True
+                if os.geteuid() != 0:
+                    logging.info("Centinel is not running as root, "
+                                 "tcpdump will not start.")
+                    root = False
+
+                td = Tcpdump()
+                tcpdump_started = False
+                try:
+                    if root:
+                        td.start()
+                        tcpdump_started = True
+                        logging.info("tcpdump started...")
+                except Exception as e:
+                    logging.warning("Failed to run tcpdump: %s" %(e))
+
                 exp = Exp(input_file)
                 exp.run()
+
+                if tcpdump_started:
+                    logging.info("Waiting for tcpdump to process packets...")
+                    # 5 seconds should be enough. this hasn't been tested on
+                    # a RaspberryPi or a Hummingboard i2
+                    time.sleep(5)
+                    td.stop()
+                    logging.info("tcpdump stopped.")
+
+                    pcap_file_name = "pcap_%s-%s.pcap.bz2" % (name, 
+                        datetime.now().isoformat())
+
+                    pcap_file_path = os.path.join(
+                        self.config['dirs']['results_dir'], pcap_file_name)
+
+                    with open(pcap_file_path, 'w:bz2') as file_p:
+                        data = bz2.compress(td.pcap())
+                        file_p.write(data)
+                        logging.info("Saved pcap to %s."
+                                     % (pcap_file_path))
+
             except Exception, e:
                 logging.error("Error in %s: %s" % (name, str(e)))
 

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -1,10 +1,10 @@
-import os
-import sys
-import json
 import glob
 import imp
+import json
 import logging
+import os
 import random
+import sys
 import tarfile
 import time
 

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -47,6 +47,7 @@ class Configuration():
         results = {}
         results['delete_after_sync'] = True
         results['files_per_archive'] = 10
+        results['upload_pcaps'] = True
         self.params['results'] = results
 
         # logging

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -47,6 +47,7 @@ class Configuration():
         results = {}
         results['delete_after_sync'] = True
         results['files_per_archive'] = 10
+        results['record_pcaps'] = True
         results['upload_pcaps'] = True
         self.params['results'] = results
 

--- a/centinel/primitives/tcpdump.py
+++ b/centinel/primitives/tcpdump.py
@@ -45,6 +45,10 @@ class Tcpdump():
         with open(self.filename, 'r') as file_p:
             return b64encode(file_p.read())
 
+    def pcap(self):
+        with open(self.filename, 'r') as file_p:
+            return file_p.read()
+
     def delete(self):
         os.remove(self.filename)
 


### PR DESCRIPTION
Enabled `tcpdump` for all experiments when running as root. `tcpdump` will start at the beginning of every experiment and stops when the experiment is over. The generated pcap file is compressed and stored where the result files are.
There is a config option to disable uploading pcaps (it is enabled by default).