### PR TITLE
Experiments with Multiple Input Files

### DIFF
--- a/centinel/data/input_1.txt
+++ b/centinel/data/input_1.txt
@@ -1,0 +1,2 @@
+www.google.com
+www.github.com

--- a/centinel/data/input_2.txt
+++ b/centinel/data/input_2.txt
@@ -1,0 +1,2 @@
+www.facebook.com
+www.twitter.com

--- a/centinel/experiment.py
+++ b/centinel/experiment.py
@@ -7,5 +7,11 @@ class ExperimentList(type):
 class Experiment:
     __metaclass__ = ExperimentList
 
+    # a list of input files that can be
+    # used in order to make use of more than
+    # one input file. If none specified, the
+    # [experiment name].txt will be used instead.
+    input_files = None
+
     def run(self):
         raise NotImplementedError

--- a/centinel/experiments/multi_input.py
+++ b/centinel/experiments/multi_input.py
@@ -1,0 +1,35 @@
+import centinel.primitives.http as http
+
+from centinel.experiment import Experiment
+
+
+class MultiInputHTTPRequestExperiment(Experiment):
+    """ This is the multiple-input-file HTTP
+    experiment. You can specify filenames using the
+    list in the class definition to have Centinel
+    load them prior to running the experiment.
+    """
+
+    name = "multi_input_http_request"
+    # filenames should not have extentions
+    # (.txt is appended automatically)
+    input_files = ['input_1', 'input_2']
+
+    def __init__(self, input_files):
+        # input handles passed using constructor
+        # are stored in a dictionary with elements
+        # like { '[filename]' : [file handle] }
+        self.input_files = input_files
+        self.results = []
+        self.host = None
+        self.path = "/"
+
+    def run(self):
+        for filename, input_file in self.input_files.items():
+            for line in input_file:
+                self.host = line.strip()
+                self.http_request()
+
+    def http_request(self):
+        result = http.get_request(self.host, self.path)
+        self.results.append(result)


### PR DESCRIPTION
This adds support for using more than one input file for an experiment.
This is especially handy when an experiment uses different input files for the same measurement. It'll be useful when running a big baseline experiment with multiple URL lists (and it's backward-compatible with older single-input experiments).

@ben-jones, will you please review this?