### PR TITLE
implemented new scheduler

### DIFF
--- a/centinel/client.py
+++ b/centinel/client.py
@@ -137,7 +137,6 @@ class Client():
             logging.error("Experiment file %s not found! Skipping." % (name))
         else:
             Exp = self.experiments[name]
-        #for name, Exp in experiments_subset:
             logging.info("Running %s..." % (name))
             exp_start_time = datetime.now().isoformat()
 

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -61,8 +61,6 @@ class Configuration():
 
         # experiments
         experiments = {}
-        experiments['random_subsetting'] = True
-        experiments['random_subset_size'] = 2
         self.params['experiments'] = experiments
 
         # server

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -102,4 +102,5 @@ class Configuration():
 
         """
         with open(config_file, 'w') as f:
-            json.dump(self.params, f)
+            json.dump(self.params, f, indent = 2,
+                      separators=(',', ': '))

--- a/centinel/experiment.py
+++ b/centinel/experiment.py
@@ -26,5 +26,9 @@ class Experiment:
     # these files will be compressed when being stored
     external_results = None
 
+    # an experiment can have external parameters
+    # that are usually set by the scheduler.
+    params = {}
+
     def run(self):
         raise NotImplementedError

--- a/centinel/experiments/baseline.py
+++ b/centinel/experiments/baseline.py
@@ -31,11 +31,16 @@ class BaselineExperiment(Experiment):
     name = "baseline"
     # country-specific, world baseline
     # this can be overridden by the main thread
-    input_files = ['country', 'world']
+    input_files = ['country.csv', 'world.csv']
 
     def __init__(self, input_files):
         self.input_files = input_files
         self.results = []
+
+        if self.params is not None:
+            # process parameters
+            if "traceroute_methods" in self.params:
+                self.traceroute_methods = self.params['traceroute_methods']
 
         if os.geteuid() != 0:
             logging.info("Centinel is not running as root, "

--- a/centinel/experiments/scheduler.info
+++ b/centinel/experiments/scheduler.info
@@ -1,0 +1,19 @@
+{
+  "baseline": {
+    "frequency": 3600,
+    "python_exps": {
+      "baseline": {
+        "params": {
+          "traceroute_methods": [
+            "tcp",
+            "udp"
+          ]
+        },
+        "input_files": [
+          "xx.csv"
+        ]
+      }
+    },
+    "last_run": 0
+  }
+}


### PR DESCRIPTION
Adds the new scheduler support to the client side. An example of the proposed scheduler can be found in `experiments/scheduler.info`. Also updated baseline experiment to support the new features.
This is still backward-compatible with the older format scheduler and experiments, but from now on, only the experiments that are in the scheduler will be run, unless the user opts to ignore scheduler.
@ben-jones, can you please review?