### PR TITLE
fixed 2 bugs in tls primitive

### DIFF
--- a/centinel/primitives/tls.py
+++ b/centinel/primitives/tls.py
@@ -11,6 +11,7 @@ def get_fingerprint(host, port=443, external=None):
     tls_error = None
     fingerprint_error = None
     exception = None
+    cert = None
     try:
         cert = ssl.get_server_certificate((host, port))
     # if this fails, there's a possibility that SSLv3 handshake was
@@ -21,6 +22,11 @@ def get_fingerprint(host, port=443, external=None):
     except Exception as exp:
         tls_error = str(exp)
         exception = exp
+
+    # this comes out as unicode, but m2crypto breaks if it gets
+    # something other than a string, so convert to ascii
+    if type(cert) == unicode or test:
+        cert = cert.encode('ascii', 'ignore')
 
     if exception is None:
         try:
@@ -35,8 +41,9 @@ def get_fingerprint(host, port=443, external=None):
     row = "%s:%s" % (host, port)
 
     if exception is not None:
-        external[row] = { "tls_error": tls_error,
-                          "fingerprint_error": fingerprint_error }
+        if external is not None:
+            external[row] = { "tls_error": tls_error,
+                              "fingerprint_error": fingerprint_error }
         raise exception
 
     if external is not None and type(external) is dict:

--- a/centinel/primitives/tls.py
+++ b/centinel/primitives/tls.py
@@ -25,12 +25,13 @@ def get_fingerprint(host, port=443, external=None):
 
     # this comes out as unicode, but m2crypto breaks if it gets
     # something other than a string, so convert to ascii
-    if type(cert) == unicode or test:
+    if type(cert) == unicode:
         cert = cert.encode('ascii', 'ignore')
 
     if exception is None:
         try:
-            x509 = M2Crypto.X509.load_cert_string(cert, M2Crypto.X509.FORMAT_PEM)
+            x509 = M2Crypto.X509.load_cert_string(cert,
+                                                  M2Crypto.X509.FORMAT_PEM)
             fingerprint = x509.get_fingerprint('sha1')
         except Exception as exp:
             fingerprint_error = str(exp)
@@ -42,13 +43,13 @@ def get_fingerprint(host, port=443, external=None):
 
     if exception is not None:
         if external is not None:
-            external[row] = { "tls_error": tls_error,
-                              "fingerprint_error": fingerprint_error }
+            external[row] = {"tls_error": tls_error,
+                             "fingerprint_error": fingerprint_error}
         raise exception
 
     if external is not None and type(external) is dict:
-        external[row] = { "cert": cert,
-                          "fingerprint": fingerprint.lower() }
+        external[row] = {"cert": cert,
+                         "fingerprint": fingerprint.lower()}
 
     return fingerprint.lower(), cert
 


### PR DESCRIPTION
1) fixed a bug in the tls primitive where we were using a variable
that had never been declared

2) the m2crypto library needs an str as input to the X509 parsing
function, but the SSL library oftens returns a unicode string. If
the cert comes back as unicode, we encode it as ascii and return

@rpanah, please review or assign someone else to review