### PR TITLE
Update tcpdump

### DIFF
--- a/centinel.py
+++ b/centinel.py
@@ -83,6 +83,9 @@ if __name__ == "__main__":
 
         configuration.write_out_config(DEFAULT_CONFIG_FILE)
 
+    # making the config globally accessible by adding it to the centinel module
+    centinel.conf = configuration.params
+
     client = centinel.client.Client(configuration.params)
     client.setup_logging()
 

--- a/centinel/client.py
+++ b/centinel/client.py
@@ -22,6 +22,7 @@ class Client():
     def __init__(self, config):
         self.config = config
         self.experiments = self.load_experiments()
+        self._meta = None
 
     def setup_logging(self):
         logging.basicConfig(filename=self.config['log']['log_file'],
@@ -89,7 +90,18 @@ class Client():
                 return True
         return False
 
+    def get_meta(self):
+        """we only want to get the meta information (our normalized IP) once,
+        so we are going to do lazy instantiation to improve performance
+
+        """
+        # get the normalized IP if we don't already have it
+        if self._meta is None:
+            self._meta = get_meta(self.config)
+        return self._meta
+
     def run(self, data_dir=None):
+
         """
         Note: this function will check the experiments directory for a
         special file, scheduler.info, that details how often each
@@ -164,7 +176,7 @@ class Client():
             results["meta"] = {}
             try:
                 logging.info("Getting metadata for experiment...")
-                meta = get_meta(self.config)
+                meta = self.get_meta()
                 results["meta"] = meta
             except Exception as exception:
                 logging.error("Error fetching metadata for "

--- a/centinel/config.py
+++ b/centinel/config.py
@@ -61,6 +61,7 @@ class Configuration():
 
         # experiments
         experiments = {}
+        experiments['tcpdump_params'] = "-i any"
         self.params['experiments'] = experiments
 
         # server

--- a/centinel/primitives/tcpdump.py
+++ b/centinel/primitives/tcpdump.py
@@ -10,6 +10,7 @@ import tempfile
 
 
 # local imports
+import centinel
 from centinel import command
 
 
@@ -26,7 +27,17 @@ class Tcpdump():
         # type and whatever you change it to will become the new
         # default value until the interpreter is restarted
         if pcap_args is None:
-            pcap_args = ["-i", "any"]
+            # use the centinel configured tcpdump options if available
+            # (if not specified by the user, this will be -i any, so
+            # the same as below
+            if hasattr(centinel.conf['experiments'], 'tcpdump_params'):
+                pcap_args = centinel.conf['experiments']['tcpdump_params']
+            # for backwards compatability, ensure that we give some
+            # pcap args for what to capture
+            else:
+                pcap_args = ["-i", "any"]
+                logging.warning("Global config not available, so falling "
+                                "back on -i any pcap args")
         self.pcap_args = pcap_args
 
     def start(self):

--- a/centinel/primitives/tcpdump.py
+++ b/centinel/primitives/tcpdump.py
@@ -16,15 +16,22 @@ from centinel import command
 class Tcpdump():
     """Class to interface between tcpdump and Python"""
 
-    def __init__(self, filename=None):
+    def __init__(self, filename=None, pcap_args=None):
         if filename is None:
             temp_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
             temp_file.close()
             filename = temp_file.name
         self.filename = filename
+        # don't change this to default value because it is a mutable
+        # type and whatever you change it to will become the new
+        # default value until the interpreter is restarted
+        if pcap_args is None:
+            pcap_args = ["-i", "any"]
+        self.pcap_args = pcap_args
 
     def start(self):
         cmd = ['sudo', 'tcpdump', '-w', self.filename]
+        cmd.extend(self.pcap_args)
         self.caller = command.Command(cmd, _tcpdump_callback)
         self.caller.start()
 


### PR DESCRIPTION
In response to #145, I have updated the tcpdump primitive to pull from all interfaces by default. I also fixed a small performance issue and added the ability to store global config options.