### PR TITLE
Running time improvement and traceroute parameter bug fix

### DIFF
--- a/centinel/experiments/baseline.py
+++ b/centinel/experiments/baseline.py
@@ -45,12 +45,9 @@ class BaselineExperiment(Experiment):
         if os.geteuid() != 0:
             logging.info("Centinel is not running as root, "
                          "traceroute will be limited to UDP.")
-            self.traceroute_methods = ["udp"]
-        else:
-            # if running as root, TCP and UDP traceroute
-            # doing all 3 methods takes a lot of time
-            # self.traceroute_methods = ["icmp", "udp", "tcp"]
-            self.traceroute_methods = ["tcp", "udp"]
+            # only change to udp if method list was not empty before
+            if self.traceroute_methods:
+                self.traceroute_methods = ["udp"]
 
     def run(self):
         for input_file in self.input_files.items():

--- a/centinel/experiments/baseline_linear.py
+++ b/centinel/experiments/baseline_linear.py
@@ -45,15 +45,17 @@ class LinearBaselineExperiment(Experiment):
         else:
             self.record_pcaps = True
 
+        if self.params is not None:
+            # process parameters
+            if "traceroute_methods" in self.params:
+                self.traceroute_methods = self.params['traceroute_methods']
+
         if os.geteuid() != 0:
             logging.info("Centinel is not running as root, "
                          "traceroute will be limited to UDP.")
-            self.traceroute_methods = ["udp"]
-        else:
-            # if running as root, TCP and UDP traceroute
-            # doing all 3 methods takes a lot of time
-            # self.traceroute_methods = ["icmp", "udp", "tcp"]
-            self.traceroute_methods = ["tcp", "udp"]
+            # only change to udp if method list was not empty before
+            if self.traceroute_methods:
+                self.traceroute_methods = ["udp"]
 
     def run(self):
         if self.record_pcaps:

--- a/centinel/experiments/scheduler.info
+++ b/centinel/experiments/scheduler.info
@@ -4,10 +4,7 @@
     "python_exps": {
       "baseline": {
         "params": {
-          "traceroute_methods": [
-            "tcp",
-            "udp"
-          ]
+          "traceroute_methods": ["tcp"]
         },
         "input_files": [
           "xx.csv"

--- a/centinel/primitives/dnslib.py
+++ b/centinel/primitives/dnslib.py
@@ -15,7 +15,7 @@ def get_ips(host, nameserver=None, record="A"):
     return lookup_domain(host, nameservers=nameservers, rtype=record)
 
 
-def lookup_domain(domain, nameservers=[], rtype="A", timeout=10):
+def lookup_domain(domain, nameservers=[], rtype="A", timeout=2):
     """Wrapper for DNSQuery method"""
     dns_exp = DNSQuery(domains=[domain], nameservers=nameservers, rtype=rtype,
                        timeout=timeout)


### PR DESCRIPTION
1. Fixed traceroute parameter initialization logic in baseline and baseline_linear;
2. Changed default traceroute method in scheduler.info to be only tcp since experiment class will change it to udp if not root, and tcp is much faster;
3. Changed socket timeout to be 2s in dnslib. This helps reducing some running time.