### PR TITLE
Bug fix: added timeout when using httplib

### DIFF
--- a/centinel/primitives/http.py
+++ b/centinel/primitives/http.py
@@ -28,10 +28,10 @@ def _get_http_request(host, path="/", headers=None, ssl=False,
 
     try:
         if ssl:
-            conn = httplib.HTTPSConnection(host)
+            conn = httplib.HTTPSConnection(host, timeout=10)
             request["ssl"] = True
         else:
-            conn = httplib.HTTPConnection(host)
+            conn = httplib.HTTPConnection(host, timeout=10)
             request["ssl"] = False
         if headers:
             conn.request("GET", path, headers=headers)


### PR DESCRIPTION
This bug won't affect baseline concurrent version since every thread has a global timeout, but WILL affect linear version. If no timeout, the process would stuck at some invalid url (in that country) forever.