### PR TITLE
force tls primitive to use SSLv3 first, closes #187

### DIFF
--- a/centinel/primitives/tls.py
+++ b/centinel/primitives/tls.py
@@ -17,7 +17,8 @@ def get_fingerprint(host, port=443, external=None, log_prefix=''):
                   "for %s:%d." % (log_prefix, host, port))
 
     try:
-        cert = ssl.get_server_certificate((host, port))
+        cert = ssl.get_server_certificate((host, port),
+                                          ssl_version=ssl.PROTOCOL_SSLv23)
     # if this fails, there's a possibility that SSLv3 handshake was
     # attempted and rejected by the server. Use TLSv1 instead.
     except ssl.SSLError:

--- a/centinel/primitives/tls.py
+++ b/centinel/primitives/tls.py
@@ -18,14 +18,14 @@ def get_fingerprint(host, port=443, external=None, log_prefix=''):
 
     try:
         cert = ssl.get_server_certificate((host, port),
-                                          ssl_version=ssl.PROTOCOL_SSLv23)
+                                          ssl_version=ssl.PROTOCOL_TLSv1)
     # if this fails, there's a possibility that SSLv3 handshake was
     # attempted and rejected by the server. Use TLSv1 instead.
     except ssl.SSLError:
         # exception could also happen here
         try:
             cert = ssl.get_server_certificate((host, port),
-                                              ssl_version=ssl.PROTOCOL_TLSv1)
+                                              ssl_version=ssl.PROTOCOL_SSLv23)
         except Exception as exp:
             tls_error = str(exp)
     except Exception as exp:


### PR DESCRIPTION
Old code switch to TLSv1 when there is SSLerror, but issue #187 seems to happen when broken SSL servers don't support TLSv1.

Forcing the first try to use SSLv3 protocol should reduce the happening times of this issue.