### PR TITLE
fixed crash in http_handler primitive that occured in ubuntu 12.04

### DIFF
--- a/centinel/primitives/http_helper.py
+++ b/centinel/primitives/http_helper.py
@@ -64,6 +64,7 @@ class ICHTTPConnection:
         c.setopt(pycurl.WRITEDATA, buf)
         c.setopt(pycurl.TIMEOUT, timeout)
         c.setopt(pycurl.ENCODING, 'identity')
+        c.setopt(pycurl.CURLOPT_NOSIGNAL, 1)
 
         if ssl:
             if self.port is None:


### PR DESCRIPTION
Addresses the pycurl crash issue on Ubuntu 12.04 systems. Resolves issue #203 