### PR TITLE
addresses pycurl crashes on ubuntu 12.04

### DIFF
--- a/centinel/primitives/http_helper.py
+++ b/centinel/primitives/http_helper.py
@@ -64,7 +64,7 @@ class ICHTTPConnection:
         c.setopt(pycurl.WRITEDATA, buf)
         c.setopt(pycurl.TIMEOUT, timeout)
         c.setopt(pycurl.ENCODING, 'identity')
-        c.setopt(pycurl.CURLOPT_NOSIGNAL, 1)
+        c.setopt(pycurl.NOSIGNAL, 1)
 
         if ssl:
             if self.port is None:


### PR DESCRIPTION
Sorry this is correct -- pyCurl doesn't use the regular curl options (it removes the CURLOPT_ prefix)

This is tested and working.  Addresses #203 