### PR TITLE
Fixed experiment name in client, initialization bug in baseline exp

### DIFF
--- a/centinel/client.py
+++ b/centinel/client.py
@@ -207,6 +207,8 @@ class Client:
                      "Look in %s for results." % (self.config['dirs']['results_dir']))
 
     def run_exp(self, name, exp_config=None, schedule_name=None):
+        if name[-3:] == ".py":
+            name = name[:-3]
         if name not in self.experiments:
             logging.error("Experiment file %s not found! Skipping." % name)
         else:

--- a/centinel/experiments/baseline.py
+++ b/centinel/experiments/baseline.py
@@ -38,6 +38,7 @@ class BaselineExperiment(Experiment):
         self.input_files = input_files
         self.results = []
         self.exclude_nameservers = []
+        self.traceroute_methods = []
 
         if self.params is not None:
             # process parameters

--- a/centinel/experiments/baseline_linear.py
+++ b/centinel/experiments/baseline_linear.py
@@ -38,6 +38,7 @@ class LinearBaselineExperiment(Experiment):
     def __init__(self, input_files):
         self.input_files = input_files
         self.results = []
+        self.traceroute_methods = []
 
         # should we do tcpdump?
         if os.geteuid() != 0:


### PR DESCRIPTION
Creating a new schedule in web interface creates an experiment with .py extension unlike earlier where schedule name itself is used.

