### PR TITLE
Try Except added to getting ip addresses of purevpn and ipvanish

### DIFF
--- a/centinel/vpn/ipvanish.py
+++ b/centinel/vpn/ipvanish.py
@@ -57,8 +57,12 @@ def create_config_files(directory):
             for line in lines:
                 if line.startswith('remote'):
                     hostname = line.split(' ')[1]
-                    ip = socket.gethostbyname(hostname)
-                    break
+                    # added because gethostbyname will fail on some hostnames
+                    try:
+                	ip = socket.gethostbyname(hostname)
+                	break
+            	    except socket.gaierror:
+            		continue
 
             if len(ip) > 0:
                 new_path = os.path.join(directory, ip + '.ovpn')

--- a/centinel/vpn/purevpn.py
+++ b/centinel/vpn/purevpn.py
@@ -56,8 +56,12 @@ def create_config_files(directory):
             for line in lines:
                 if line.startswith('remote'):
                     hostname = line.split(' ')[1]
-                    ip = socket.gethostbyname(hostname)
-                    break
+                    # added because gethostbyname will fail on some hostnames
+                    try:
+                	ip = socket.gethostbyname(hostname)
+                	break
+            	    except socket.gaierror:
+            		continue
 
             if len(ip) > 0:
                 new_path = os.path.join(directory, ip + '.ovpn')


### PR DESCRIPTION
The line `ip = socket.gethostbyname(hostname)` would cause the following error before the fix
`[Errno 8] nodename nor servname provided, or not known`